### PR TITLE
Add NULL check for context

### DIFF
--- a/CustomLocalePlugin.inc.php
+++ b/CustomLocalePlugin.inc.php
@@ -27,7 +27,10 @@ class CustomLocalePlugin extends GenericPlugin {
 
 			$request = Application::get()->getRequest();
 			$context = $request->getContext();
-
+			if ($context == NULL ) {
+				// No context abort registration
+				return false;
+			}
 			import('lib.pkp.classes.file.ContextFileManager');
 			$contextFileManager = new ContextFileManager($context->getId());
 			$customLocalePathBase = $contextFileManager->getBasePath() . "customLocale/$locale/";


### PR DESCRIPTION
Hi Alec @asmecher ,

I added this fix previously for 3.1.2.
As we are currently upgrading our OJS instances to 3.2.1-1 I found that the upgrade script had an error because the plugin was expecting a context from a request during registration.

Error output from upgrade.php
```
nw@serv3:/web/htdocs-journals-3-2$ sudo -u www-data php tools/upgrade.php check             [55/1824]
PHP Fatal error:  Uncaught Error: Call to a member function getId() on null in /web/htdocs-journals-3
-2/plugins/generic/customLocale/CustomLocalePlugin.inc.php:32
Stack trace:                                      
#0 /web/htdocs-journals-3-2/lib/pkp/classes/plugins/PluginRegistry.inc.php(69): CustomLocalePlugin->$
egister('generic', 'plugins/generic...', NULL)                                
#1 /web/htdocs-journals-3-2/lib/pkp/classes/plugins/PluginRegistry.inc.php(144): PluginRegistry::reg$
ster('generic', Object(CustomLocalePlugin), 'plugins/generic...', NULL)
#2 /web/htdocs-journals-3-2/lib/pkp/classes/cliTool/CliTool.inc.php(65): PluginRegistry::loadCategor$
('generic')                                           
#3 /web/htdocs-journals-3-2/lib/pkp/classes/cliTool/UpgradeTool.inc.php(35): CommandLineTool->__cons$
ruct(Array)                   
#4 /web/htdocs-journals-3-2/tools/upgrade.php(21): UpgradeTool->__construct(Array)
#5 {main}                                                               
  thrown in /web/htdocs-journals-3-2/plugins/generic/customLocale/CustomLocalePlugin.inc.php on line
32
```

I dont know why this was not coming up in other installations?
