### PR TITLE
Use current app locale for initial list of locale files

### DIFF
--- a/controllers/grid/CustomLocaleGridHandler.inc.php
+++ b/controllers/grid/CustomLocaleGridHandler.inc.php
@@ -237,7 +237,11 @@ class CustomLocaleGridHandler extends GridHandler {
 
 		$locales = $request->getContext()->getSupportedLocaleNames();
 		$locale = $request->getUserVar('locale');
-		if (!in_array($locale, array_keys($locales))) $locale = LOCALE_DEFAULT;
+		// consider app locale as well
+		if (!in_array($locale, array_keys($locales))) {
+			$locale = AppLocale::getLocale();
+			if (!in_array($locale, array_keys($locales))) $locale = LOCALE_DEFAULT;
+		}
 
 		$searchField = $request->getUserVar('searchField');
 		$searchMatch = $request->getUserVar('searchMatch');


### PR DESCRIPTION
This small code change provides a solution to the problem described in https://forum.pkp.sfu.ca/t/ojs-3-3-0-8-custom-locale-plugin-language-cannot-be-changed/72017 . It had bitten our users also. It is not intuitive to switch the language using the search function of the customLocale plugin, because the language switch is hidden until the search button is clicked. So journal administrators usually do the language change in the frontend and then wonder why still the locale file list in the default locale is displayed by the plugin.

The currently used app language (or locale) is now used to present the initial list of locale files in this language to the journal administrator. This list and the language can still be changed using the search function.

Unfortunately, I was not able to apply the change to the OJS 3.4 main branch, because many of the functions were removed from controllers/grid/CustomLocaleGridHandler.php . 

